### PR TITLE
Add fix for findInDomAncestry and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ npm install @grrr/hansel
 Import into your main Javascript file:
 
 ```js
-import { enhance, handle } from "hansel";
+import { enhance, handle } from '@grrr/hansel';
 
 enhance(document.documentElement, {
     enhancer1(elm) {

--- a/dist/hansel.js
+++ b/dist/hansel.js
@@ -3,23 +3,29 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.default = exports.handle = exports.enhance = void 0;
+exports.default = exports.handle = exports.enhance = exports.HANDLER_ATTRIBUTE = exports.ENHANCER_ATTRIBUTE = void 0;
 
 var _util = require("./util");
 
+var ENHANCER_ATTRIBUTE = 'data-enhancer';
+exports.ENHANCER_ATTRIBUTE = ENHANCER_ATTRIBUTE;
+var HANDLER_ATTRIBUTE = 'data-handler';
 /**
- * enhance :: DomNode -> Object -> Void
+ * enhance :: DomNode -> Object -> Array
  */
+
+exports.HANDLER_ATTRIBUTE = HANDLER_ATTRIBUTE;
+
 var enhance = function enhance(root, enhancers) {
   if (!enhancers) {
     return;
   }
 
-  var enhancedElements = root.querySelectorAll("[data-enhancer]");
-  return Array.prototype.map.call(enhancedElements, function (elm) {
+  var enhancedElements = (root.hasAttribute(ENHANCER_ATTRIBUTE) ? [root] : []).concat((0, _util.toArray)(root.querySelectorAll("[".concat(ENHANCER_ATTRIBUTE, "]"))));
+  return enhancedElements.map(function (elm) {
     // Allow multiple, comma-separated enhancers.
-    var enhancerCollection = elm.getAttribute("data-enhancer");
-    enhancerCollection.split(",").forEach(function (enhancer) {
+    var enhancerCollection = elm.getAttribute(ENHANCER_ATTRIBUTE);
+    enhancerCollection.split(',').forEach(function (enhancer) {
       if (typeof enhancers[enhancer] === "function") {
         return enhancers[enhancer](elm);
       } else {
@@ -56,7 +62,7 @@ var handle = function handle(root, handlers) {
     } // Allow multiple, comma-separated handlers.
 
 
-    var handlerCollection = trigger.getAttribute('data-handler');
+    var handlerCollection = trigger.getAttribute(HANDLER_ATTRIBUTE);
     handlerCollection.split(',').forEach(function (handler) {
       if (typeof handlers[handler] === 'function') {
         handlers[handler](trigger, e);

--- a/dist/util.js
+++ b/dist/util.js
@@ -3,7 +3,9 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.warn = exports.findElementWithHandler = exports.findInDomAncestry = void 0;
+exports.toArray = exports.warn = exports.findElementWithHandler = exports.findInDomAncestry = void 0;
+
+var _hansel = require("./hansel");
 
 /**
  * Generic function for traversing a DOM, returning the first element
@@ -13,7 +15,7 @@ exports.warn = exports.findElementWithHandler = exports.findInDomAncestry = void
  */
 var findInDomAncestry = function findInDomAncestry(predicate) {
   return function (node) {
-    return typeof node.nodeType === 'undefined' || node.nodeType === Node.DOCUMENT_NODE ? undefined : predicate(node) ? node : findInDomAncestry(predicate)(node.parentNode);
+    return !node || node.nodeType === Node.DOCUMENT_NODE ? undefined : predicate(node) ? node : findInDomAncestry(predicate)(node.parentNode);
   };
 };
 /**
@@ -25,7 +27,7 @@ var findInDomAncestry = function findInDomAncestry(predicate) {
 
 exports.findInDomAncestry = findInDomAncestry;
 var findElementWithHandler = findInDomAncestry(function (x) {
-  return x.hasAttribute('data-handler');
+  return x.hasAttribute(_hansel.HANDLER_ATTRIBUTE);
 });
 /**
  * console.warn proxy.
@@ -43,5 +45,17 @@ var warn = function warn(elm) {
 
   return typeof elm.ownerDocument.defaultView.console !== 'undefined' ? (_elm$ownerDocument$de = elm.ownerDocument.defaultView.console).warn.apply(_elm$ownerDocument$de, args) : undefined;
 };
+/**
+ * Crude and incomplete replacement for Array.from
+ *
+ * nodesToArray :: NodeList -> Array
+ */
+
 
 exports.warn = warn;
+
+var toArray = function toArray(xs) {
+  return Array.prototype.slice.call(xs);
+};
+
+exports.toArray = toArray;

--- a/src/util.js
+++ b/src/util.js
@@ -7,11 +7,12 @@ import { HANDLER_ATTRIBUTE } from './hansel';
  * findInDomAncestry :: (DomNode -> Bool) -> DomNode -> ?DomNode
  */
 export const findInDomAncestry = predicate => node =>
-    typeof node.nodeType === 'undefined' || node.nodeType === Node.DOCUMENT_NODE
-    ? undefined
-    : predicate(node)
-    ? node
-    : findInDomAncestry(predicate)(node.parentNode);
+  !node || node.nodeType === Node.DOCUMENT_NODE
+  ? undefined
+  : predicate(node)
+  ? node
+  : findInDomAncestry(predicate)(node.parentNode);
+
 
 /**
  * Find element with data-handler attribute.

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -26,5 +26,7 @@ describe('Utilities', () => {
     expect(findElementWithHandler(c2)).toBe(c2);
     expect(findElementWithHandler(d)).toBe(b);
     expect(findElementWithHandler(e)).toBeUndefined();
+
+    expect(findElementWithHandler(byId('none'))).toBeUndefined();
   });
 });


### PR DESCRIPTION
When a node is removed, `findInDomAncestry` will fail since `node.nodeType` doesn't exist because `node` itself will return `null`. Checking for `typeof node === 'null'` or `typeof node === 'undefined'` doesn't work however, since the 'null' `node` still returns `typeof node === 'object'` ¯\\_(ツ)_/¯
The 'falsy' check for the existence of the `node` itself seemed like the most logic solution.

Also added the proper import to the readme and an updated distribution.