### PR TITLE
Remove warnings for empty attributes and allow spaces

### DIFF
--- a/src/hansel.js
+++ b/src/hansel.js
@@ -21,7 +21,10 @@ export const enhance = (root, enhancers) => {
   return enhancedElements.map(elm => {
     // Allow multiple, comma-separated enhancers.
     const enhancerCollection = elm.getAttribute(ENHANCER_ATTRIBUTE);
-    enhancerCollection.split(',').forEach(enhancer => {
+    if (!enhancerCollection) {
+      return;
+    }
+    enhancerCollection.split(',').map(enhancer => enhancer.trim()).forEach(enhancer => {
       if (typeof enhancers[enhancer] === 'function') {
         enhancers[enhancer](elm);
       } else {
@@ -55,7 +58,10 @@ export const handle = (root, handlers) => {
 
     // Allow multiple, comma-separated handlers.
     const handlerCollection = trigger.getAttribute(HANDLER_ATTRIBUTE);
-    handlerCollection.split(',').forEach(handler => {
+    if (!handlerCollection) {
+      return;
+    }
+    handlerCollection.split(',').map(handler => handler.trim()).forEach(handler => {
       if (typeof handlers[handler] === 'function') {
         handlers[handler](trigger, e);
       } else {

--- a/src/hansel.js
+++ b/src/hansel.js
@@ -22,7 +22,7 @@ export const enhance = (root, enhancers) => {
     // Allow multiple, comma-separated enhancers.
     const enhancerCollection = elm.getAttribute(ENHANCER_ATTRIBUTE);
     if (!enhancerCollection) {
-      return;
+      return elm;
     }
     enhancerCollection.split(',').map(enhancer => enhancer.trim()).forEach(enhancer => {
       if (typeof enhancers[enhancer] === 'function') {

--- a/test/hansel.test.js
+++ b/test/hansel.test.js
@@ -238,4 +238,26 @@ describe('Hansel.enhance', () => {
       'Non-existing enhancer: "%s" on %o', 'nix', div
     );
   });
+
+  test('Should not warn of empty enhancer attributes', () => {
+    const enhancers = getMockFunctions();
+
+    document.body.innerHTML = '<div data-enhancer=""></div>';
+
+    const div = document.querySelector('div');
+    div.ownerDocument.defaultView.console.warn = jest.fn();
+
+    enhance(document.documentElement, enhancers);
+    expect(div.ownerDocument.defaultView.console.warn).not.toBeCalled();
+  });
+
+  test('Should allow enhancer attribute spaces', () => {
+    const enhancers = getMockFunctions();
+
+    document.body.innerHTML = '<div data-enhancer="foo,bar, foo, bar"></div>';
+    enhance(document.documentElement, enhancers);
+
+    expect(enhancers.foo.mock.calls).toHaveLength(2);
+    expect(enhancers.bar.mock.calls).toHaveLength(2);
+  });
 });


### PR DESCRIPTION
Adds two minor adjustments:

- Allow spaces in attributes: `data-enhancer="fooBar, barFoo"`
- Doesn't warn when an attribute is empty, when used with template conditionals for example: `data-enhancer="{{ if foo ? 'bar' : '' }}"`