### PR TITLE
Allow circumvention of disallowed modifier keys in handler

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,6 +14,7 @@
         "functions": "never",
     }],
     "quote-props": ["error", "consistent"],
+    "quotes": "off",
     "arrow-parens": "off",
     "no-confusing-arrow": "off",
     "no-nested-ternary": "off",

--- a/.eslintrc
+++ b/.eslintrc
@@ -19,5 +19,6 @@
     "no-nested-ternary": "off",
     "implicit-arrow-linebreak": "off",
     "arrow-body-style": "off",
+    "prefer-destructuring": "off",
   }
 }

--- a/README.md
+++ b/README.md
@@ -31,23 +31,19 @@ Import into your main JavaScript file:
 import { enhance, handle } from '@grrr/hansel';
 
 enhance(document.documentElement, {
-    enhancer1(elm) {
-        // Enhance elements with this enhancer
-    },
-    enhancer2(elm) {
-    },
-    enhancerN(elm) {
-    },
+  enhancer1(elm) {
+    // Enhance elements with this enhancer.
+  },
+  enhancer2(elm) { /* */ },
+  enhancerN(elm) { /* */ },
 });
 
 handle(document.documentElement, {
-    handler1(elm, event) {
-        // Handle clicks on elements with this handler
-    },
-    handler2(elm, event) {
-    },
-    handlerN(elm, event) {
-    },
+  handler1(elm, event) {
+    // Handle clicks on elements with this handler.
+  },
+  handler2(elm, event) { /* */ },
+  handlerN(elm, event) { /* */ },
 });
 ```
 
@@ -59,13 +55,13 @@ import { enhancer as fooEnhancer, handler as fooHandler } from './foo';
 import { enhancer as barEnhancer, handler as barHandler } from './bar';
 
 enhance(document.documentElement, {
-    fooEnhancer,
-    barEnhancer,
+  fooEnhancer,
+  barEnhancer,
 });
 
 handle(document.documentElement, {
-    fooHandler,
-    barHandler,
+  fooHandler,
+  barHandler,
 });
 ```
 
@@ -79,7 +75,7 @@ The second argument is a lookup table for enhancer functions. The value of the `
 
 enhance(document.documentElement, {
   foo(elm) {
-    console.log(elm.getAttribute('data-message')); // "Hello!"
+    console.log(elm.getAttribute('data-message')); //=> "Hello!"
   }
 });
 ```
@@ -92,14 +88,14 @@ Multiple enhancers are possible by comma-separating them:
 
 ## Handlers
 
-Handlers are called on click, using a global event listener on the `document`. Meta-clicks are caught and *not* passed on to the handler.
+Handlers are called on click, using a global event listener on the `document`. 
 
 ```js
 // Given <button data-handler="shout" data-message="Hello!">shout</button>
 
 handle(document.documentElement, {
   shout(elm, e) {
-    alert(elm.getAttribute('data-message')); // "Hello!"
+    alert(elm.getAttribute('data-message')); //=> "Hello!"
     e.preventDefault();
   }
 });
@@ -109,6 +105,37 @@ Multiple handlers are possible by comma-separating them:
 
 ```html
 <a data-handler="foo,bar" href="/">Do the thing</a>
+```
+
+### Options
+
+It's possible to register a handler with options. To do so, register the handler via an object with a `fn` and `options` key:
+
+```js
+handle(document.documentElement, {
+  foo(elm, e) { /* */ },
+  bar(elm, e) { /* */ },
+  baz: {
+    fn: baz(el, e) {
+      // The handler function.
+    },
+    options: {
+      // The handler options.
+    },
+  },
+});
+```
+
+The following options are available:
+
+#### allowModifierKeys
+
+By default, modifier-clicks ([metaKey](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/metaKey), [ctrlKey](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/ctrlKey), [altKey](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/altKey) and [shiftKey](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/shiftKey)) on anchors (`<a>`) are caught, and are *not* passed on to the handler. To disable this behaviour, register the handler with the `allowModifierKeys` option:
+
+```js
+options: {
+  allowModifierKeys: true,
+},
 ```
 
 ## Furthermore

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Multiple handlers are possible by comma-separating them:
 
 ### Options
 
-It's possible to register a handler with options. To do so, register the handler via an object with a `fn` and `options` key:
+It's possible to register a handler with options. To do so, register the handler via an object with an `fn` and `options` key:
 
 ```js
 handle(document.documentElement, {

--- a/src/hansel.mjs
+++ b/src/hansel.mjs
@@ -49,7 +49,7 @@ export const enhance = (root, enhancers) => {
   return enhancedElements.map(elm => {
     const enhancerCollection = elm.getAttribute(ENHANCER_ATTRIBUTE);
     if (!enhancerCollection) {
-      return;
+      return elm;
     }
     // Allow multiple, comma-separated enhancers.
     enhancerCollection.split(',').map(enhancer => enhancer.trim()).forEach(enhancer => {
@@ -82,7 +82,7 @@ export const handle = (root, handlers) => {
     // Allow multiple, comma-separated handlers.
     handlerCollection.split(',').map(handler => handler.trim()).forEach(handler => {
       const fn = getHandlerFn(handlers[handler]);
-      const options = getHandlerOptions(handlers[handler])
+      const options = getHandlerOptions(handlers[handler]);
       // Honour default behaviour on `<a>`s when using modifier keys when clicking,
       // but only when not explicitly allowed via `allowModifierKeys` handler option:
       // - Meta / Ctrl opens in new tab.

--- a/src/util.mjs
+++ b/src/util.mjs
@@ -2,6 +2,16 @@ import { closest } from '@grrr/utils';
 import { HANDLER_ATTRIBUTE } from './constants';
 
 /**
+ * Determine if given DOM element is an anchor (`<a>`).
+ */
+export const isAnchor = tag => tag.tagName.toLowerCase() === 'a';
+
+/**
+ * Determine if KeyboardEvent includes a modifier key.
+ */
+export const isModifierKey = e => e.metaKey || e.ctrlKey || e.altKey || e.shiftKey;
+
+/**
  * Find element with data-handler attribute.
  *
  * findElementWithHandler :: DomNode -> ?DomNode

--- a/test/hansel.test.js
+++ b/test/hansel.test.js
@@ -8,7 +8,7 @@ const getMockFunctions = () => ({
   baz: jest.fn(),
 });
 
-const clickEvent = (e = {
+const CLICK_EVENT = {
   bubbles: true,
   cancelable: true,
   view: window,
@@ -23,13 +23,9 @@ const clickEvent = (e = {
   metaKey: false,
   button: 0,
   relatedTarget: undefined,
-}) => {
-  const evt = document.createEvent('MouseEvents');
-  evt.initMouseEvent('click', e.bubbles, e.cancelable, e.view, e.detail,
-    e.screenX, e.screenY, e.clientX, e.clientY, e.ctrlKey, e.altKey, e.shiftKey,
-    e.metaKey, e.button, e.relatedTarget);
-  return evt;
 };
+
+const clickEvent = e => new MouseEvent('click', { ...CLICK_EVENT, ...e });
 
 describe('Hansel.handle', () => {
   test('Should listen to handler-clicks', () => {


### PR DESCRIPTION
I've run into this multiple times before, mainly while implementing tracking/analytics. It poses a problem, because: 

- While testing ⌘-clicking is easier than constantly toggling `e.preventDefault()`.
- It discards real world and valid clicks in analytics/tracking.

Note: 

- Tests are not yet updated, because I wanted to discuss first.
- Had a boolean at first, but that's quite messy since more than 1 should already be a good candidate for named parameters of course. But let's not head into v2 too soon. This makes calling the function doable, leaving room for future options too.
- How about the parameter name? It's gonna _negate_ somewhere anyway, be it as the argument or in our code...

---

Example:

```js
handle(document.documentElement, {
  classToggler,
  cookieBarAccept,
  discoveryScrollerCardClick,
  foldoutItem,
  frontPageSwitch,
  languageSwitch,
  lazyVideoEmbedClose,
  lazyVideoEmbedPlay,
  siteNavToggler,
});

handle(document.documentElement, {
  gtmClickHandler,
}, {
  allowModifierKeys: true,
});
```