### PR TITLE
Add disableWarnings option to cater for multi-method invocation

### DIFF
--- a/src/hansel.mjs
+++ b/src/hansel.mjs
@@ -4,7 +4,9 @@ import { ENHANCER_ATTRIBUTE, HANDLER_ATTRIBUTE } from './constants';
 /**
  * enhance :: DomNode -> Object -> Array
  */
-export const enhance = (root, enhancers) => {
+export const enhance = (root, enhancers, {
+  disableWarnings = false,
+} = {}) => {
   if (!enhancers) {
     return [];
   }
@@ -24,7 +26,7 @@ export const enhance = (root, enhancers) => {
     enhancerCollection.split(',').map(enhancer => enhancer.trim()).forEach(enhancer => {
       if (typeof enhancers[enhancer] === 'function') {
         enhancers[enhancer](elm);
-      } else {
+      } else if (!disableWarnings) {
         warn(elm, 'Non-existing enhancer: "%s" on %o', enhancer, elm);
       }
     });
@@ -35,7 +37,10 @@ export const enhance = (root, enhancers) => {
 /**
  * handle :: DomNode -> Object -> Void
  */
-export const handle = (root, handlers, { allowModifierKeys = false } = {}) => {
+export const handle = (root, handlers, {
+  allowModifierKeys = false,
+  disableWarnings = false,
+} = {}) => {
   if (!handlers) {
     return;
   }
@@ -60,7 +65,7 @@ export const handle = (root, handlers, { allowModifierKeys = false } = {}) => {
     handlerCollection.split(',').map(handler => handler.trim()).forEach(handler => {
       if (typeof handlers[handler] === 'function') {
         handlers[handler](trigger, e);
-      } else {
+      } else if (!disableWarnings) {
         warn(trigger, 'Non-existing handler: "%s" on %o', handler, trigger);
       }
     });

--- a/test/hansel.test.js
+++ b/test/hansel.test.js
@@ -254,7 +254,7 @@ describe('Hansel.enhance', () => {
     expect(enhancers.baz.mock.calls).toHaveLength(1);
   });
 
-  test('Should warn of unknown enhancers', () => {
+  test('Should warn of unknown enhancers (disableWarnings: false)', () => {
     const enhancers = getMockFunctions();
 
     document.body.innerHTML = '<div data-enhancer="nix"></div>';
@@ -266,6 +266,20 @@ describe('Hansel.enhance', () => {
     expect(div.ownerDocument.defaultView.console.warn).toHaveBeenCalledWith(
       'Non-existing enhancer: "%s" on %o', 'nix', div
     );
+  });
+
+  test(`Shouldn't warn of unknown enhancers (disableWarnings: true)`, () => {
+    const enhancers = getMockFunctions();
+
+    document.body.innerHTML = '<div data-enhancer="nix"></div>';
+
+    const div = document.querySelector('div');
+    div.ownerDocument.defaultView.console.warn = jest.fn();
+
+    enhance(document.documentElement, enhancers, {
+      disableWarnings: true,
+    });
+    expect(div.ownerDocument.defaultView.console.warn).not.toHaveBeenCalled();
   });
 
   test('Should not warn of empty enhancer attributes', () => {


### PR DESCRIPTION
The change in #14 creates the use case of invoking `handle` twice, which will result in a warning for handlers that are invoke by the other function. 

I'm not sure if this the right solution, but it's definitely a way to make 'the problem' go away. Thoughts?

Plus: not sure about `disableWarnings`. They're enabled by default, so 'disabling' seems logic. Could also be `enableWarnings/showWarnings` which could be set to `true` by default. Although _disabling_ feels kind of explicit...